### PR TITLE
デプロイのSlack通知のコメント解除

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,8 @@ jobs:
     needs: [Test]
     name: Deploy
     runs-on: ubuntu-latest
-    # outputs:
-    #   done: ${{ steps.check.outputs.message }}
+    outputs:
+      done: ${{ steps.check.outputs.message }}
     environment: production
 
     steps:
@@ -86,42 +86,42 @@ jobs:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
         service: ${{ env.ECS_SERVICE }}
         cluster: ${{ env.ECS_CLUSTER }}
-        wait-for-service-stability: true
-    # - id: check
-    #     if: ${{ always() }}
-    #     run: echo "::set-output name=message::Deploy ${{ (job.status == 'success' && '✅') || '❌' }}"
+        wait-for-service-stability: false
+    - id: check
+        if: ${{ always() }}
+        run: echo "::set-output name=message::Deploy ${{ (job.status == 'success' && '✅') || '❌' }}"
 
   # 上記までの処理が成功した場合、以下のSlack通知処理が実行される
-  # Notify_succeed:
-  #   if: success()
-  #   runs-on: ubuntu-latest
-  #   needs: [Test, Deploy]
-  #   steps:
-  #   - name: Slack Notification Success
-  #     uses: rtCamp/action-slack-notify@v2.0.0
-  #     env:
-  #       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       SLACK_USERNAME: GitHub Actions
-  #       SLACK_TITLE: 'Success to Deploy to ECS :rocket:'
-  #       SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
-  #       SLACK_COLOR: '#5cb85c'
-  #       SLACK_MESSAGE: '${{ needs.Test.outputs.done }} ${{ needs.Deploy.outputs.done }}'
+  Notify_succeed:
+    if: success()
+    runs-on: ubuntu-latest
+    needs: [Deploy]
+    steps:
+    - name: Slack Notification Success
+      uses: rtCamp/action-slack-notify@v2.0.0
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_USERNAME: GitHub Actions
+        SLACK_TITLE: 'Success to Deploy to ECS :rocket:'
+        SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+        SLACK_COLOR: '#5cb85c'
+        SLACK_MESSAGE: '${{ needs.Deploy.outputs.done }}'
   
   # 上記までの処理のいずれかが失敗した場合、以下のSlack通知処理が実行される
-  # Notify_failure:
-  #   if: failure()
-  #   runs-on: ubuntu-latest
-  #   needs: [Test, Deploy]
-  #   steps:
-  #   - name: Slack Notification Failure
-  #     uses: rtCamp/action-slack-notify@v2.0.0
-  #     env:
-  #       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       SLACK_USERNAME: GitHub Actions
-  #       SLACK_TITLE: 'Failure to Deploy to ECS :boom:'
-  #       SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
-  #       SLACK_COLOR: '#dc143c'
-  #       SLACK_MESSAGE: '${{ needs.Test.outputs.done }} ${{ needs.Deploy.outputs.done }}'
+  Notify_failure:
+    if: failure()
+    runs-on: ubuntu-latest
+    needs: [Deploy]
+    steps:
+    - name: Slack Notification Failure
+      uses: rtCamp/action-slack-notify@v2.0.0
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_USERNAME: GitHub Actions
+        SLACK_TITLE: 'Failure to Deploy to ECS :boom:'
+        SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+        SLACK_COLOR: '#dc143c'
+        SLACK_MESSAGE: '${{ needs.Deploy.outputs.done }}'
   
   # 上記までの処理のいずれかが中止した場合、以下のSlack通知処理が実行される
   # Notify_failure:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,15 +87,14 @@ jobs:
         service: ${{ env.ECS_SERVICE }}
         cluster: ${{ env.ECS_CLUSTER }}
         wait-for-service-stability: false
-    - id: check
-        if: ${{ always() }}
-        run: echo "::set-output name=message::Deploy ${{ (job.status == 'success' && '✅') || '❌' }}"
+    # - id: check
+    #     if: ${{ always() }}
+    #     run: echo "::set-output name=message::Deploy ${{ (job.status == 'success' && '✅') || '❌' }}"
 
   # 上記までの処理が成功した場合、以下のSlack通知処理が実行される
   Notify_succeed:
     if: success()
     runs-on: ubuntu-latest
-    needs: [Deploy]
     steps:
     - name: Slack Notification Success
       uses: rtCamp/action-slack-notify@v2.0.0
@@ -105,13 +104,12 @@ jobs:
         SLACK_TITLE: 'Success to Deploy to ECS :rocket:'
         SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
         SLACK_COLOR: '#5cb85c'
-        SLACK_MESSAGE: '${{ needs.Deploy.outputs.done }}'
+        SLACK_MESSAGE: 'デプロイに成功しました。Run number : #${{ github.run_number }}'
   
   # 上記までの処理のいずれかが失敗した場合、以下のSlack通知処理が実行される
   Notify_failure:
     if: failure()
     runs-on: ubuntu-latest
-    needs: [Deploy]
     steps:
     - name: Slack Notification Failure
       uses: rtCamp/action-slack-notify@v2.0.0
@@ -121,7 +119,7 @@ jobs:
         SLACK_TITLE: 'Failure to Deploy to ECS :boom:'
         SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
         SLACK_COLOR: '#dc143c'
-        SLACK_MESSAGE: '${{ needs.Deploy.outputs.done }}'
+        SLACK_MESSAGE: 'デプロイに失敗しました。Run number : #${{ github.run_number }}'
   
   # 上記までの処理のいずれかが中止した場合、以下のSlack通知処理が実行される
   # Notify_failure:


### PR DESCRIPTION
次のとおり実装しましたので、レビューをお願いします。
- デプロイのSlack通知のコメント解除
- `wait-for-service-stability:`を`true`から`false`に変更