### PR TITLE
体験詳細ページへリダイレクト対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ gem 'meta-tags'
 # 環境変数の管理
 gem 'dotenv-rails'
 
+# デバッグツール
+gem 'pry-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     devise (4.8.1)
@@ -228,6 +229,11 @@ GEM
     parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.4.2)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (3.3.2)
     public_suffix (4.0.7)
     puma (4.3.12)
@@ -414,6 +420,7 @@ DEPENDENCIES
   net-pop
   net-smtp
   pg (>= 0.18, < 2.0)
+  pry-rails
   psych (~> 3.1)
   puma (~> 4.1)
   rails (= 6.1.6.1)

--- a/README.md
+++ b/README.md
@@ -18,18 +18,20 @@
 - そこで、お茶生産者とお茶摘み体験に興味がある人とをマッチングし、お茶摘みを体験することで、単なる労働力不足の解消だけでなく、「お茶ファン」を拡大し、お茶の消費量の増大に少しでも貢献できるのではないかと考え、このアプリを開発しました。
 
 ## アプリの機能
-- 体験検索機能（ransack）
+- 体験検索機能（`ransack`）
 - 体験予約機能
 - 体験投稿機能
 - お気に入り登録機能（非同期処理）
-- GoogleMap表示機能（GoogleMap API）  
-- 体験にコメントを付ける機能（raty）
-- 認証機能（devise）  
-- 画像投稿機能（S3,carrierwave）
-- ページネーション機能（kaminari）
-- SEO対策
-    - `Google Analytics`の導入
-    - metaタグの設定（meta-tags）
+- GoogleMap表示機能（`GoogleMap API`）  
+- 体験にコメントを付ける機能（`raty`）
+- 認証機能（`devise`）  
+- 画像投稿機能（`S3`,`carrierwave`）
+- ページネーション機能（`kaminari`）
+- その他
+    - SEO対策
+        - `Google Analytics`の導入
+        - metaタグの設定（meta-tags）
+    - デバッグツール（`pry-rails`）
 ## 使用技術
 - フロントエンド
     - HTML,CSS,Scss,Bootstrap

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,8 +5,8 @@ class ReviewsController < ApplicationController
   end
 
   def create
-    Review.create(review_params)
-    redirect_to controller: :experiences, action: :index
+    review = Review.create(review_params)
+    redirect_to controller: :experiences, action: :show, id: review.experience_id
   end
 
   private


### PR DESCRIPTION
次のとおり実装しましたので、レビューをお願いします。
## 実装内容
- 更新後、体験詳細ページにリダイレクトするよう、修正
- デバッグツール`pry-rails`を導入

## 参考記事
- [デバックツール(pry-rails)について　binding.pryの使い方](https://qiita.com/STHEXA/items/1de2411cb3987066c9b9)