### PR TITLE
体験登録のバリデーションの追加

### DIFF
--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -22,10 +22,13 @@ class ExperiencesController < ApplicationController
   end
 
   def create
-    experience = Experience.new(experience_params)
-    experience.user_id = current_user.id
-    experience.save!
-    redirect_to action: :index
+    @experience = Experience.new(experience_params)
+    @experience.user_id = current_user.id
+    if @experience.save
+      redirect_to action: :index
+    else
+      render "new"
+    end
   end
 
   def edit

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -2,14 +2,23 @@ class Experience < ApplicationRecord
   belongs_to :user
   has_many :bookings, dependent: :destroy
   has_many :booking_users, through: :bookings, source: :user
-  # バリデーションと関連付け
   has_many :likes, dependent: :destroy
-  # experience.liked_usersでexperienceをいいねしているユーザの一覧を取得できる
   has_many :liked_users, through: :likes, source: :user
-  
   has_many :reviews, dependent: :destroy
-  
+
   mount_uploader :image, ImageUploader
+
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :fee, presence: true, length: { maximum: 10 }
+  validates :prefecture, presence: true, length: { maximum: 10 }
+  validates :region, presence: true, length: { maximum: 10 }
+  validates :content, presence: true, length: { maximum: 100 }
+  validates :start_datetime, presence: true
+  validates :finish_datetime, presence: true
+  validates :language, presence: true, length: { maximum: 10 }
+  validates :address, presence: true, length: { maximum: 30 }
+  validates :latitude, presence: true
+  validates :longitude, presence: true
 
   # geocoderの適用
   # :addressを登録した際にgeocoderが緯度経度ののカラムにも自動的に値を入れてくれる

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -8,15 +8,15 @@ class Experience < ApplicationRecord
 
   mount_uploader :image, ImageUploader
 
-  validates :title, presence: true, length: { maximum: 30 }
-  validates :fee, presence: true, length: { maximum: 10 }
-  validates :prefecture, presence: true, length: { maximum: 10 }
-  validates :region, presence: true, length: { maximum: 10 }
-  validates :content, presence: true, length: { maximum: 100 }
+  validates :title, presence: true, length: {maximum: 30}
+  validates :fee, presence: true, length: {maximum: 10}
+  validates :prefecture, presence: true, length: {maximum: 10}
+  validates :region, presence: true, length: {maximum: 10}
+  validates :content, presence: true, length: {maximum: 100}
   validates :start_datetime, presence: true
   validates :finish_datetime, presence: true
-  validates :language, presence: true, length: { maximum: 10 }
-  validates :address, presence: true, length: { maximum: 30 }
+  validates :language, presence: true, length: {maximum: 10}
+  validates :address, presence: true, length: {maximum: 30}
   validates :latitude, presence: true
   validates :longitude, presence: true
 

--- a/app/views/experiences/edit.html.erb
+++ b/app/views/experiences/edit.html.erb
@@ -1,5 +1,7 @@
 <h1>体験を更新する</h1>
 <%= form_with model: @experience, url:"/experiences/#{@experience.id}", method: :patch, class: "card col-md-6", local: true do |f| %>
+  <%# エラーメッセージの表示 %>
+  <%= render 'layouts/error_messages', model: f.object %>
   <%= render partial: "form", locals: {f: f} %>
   <%= f.submit "掲載を更新する", class:"btn btn-success" %>
 <% end %>

--- a/app/views/experiences/new.html.erb
+++ b/app/views/experiences/new.html.erb
@@ -1,5 +1,7 @@
 <h1>体験をホストする</h1>
 <%= form_with model: @experience, class: "card col-md-6", local: true do |f| %>
+    <%# エラーメッセージの表示 %>
+    <%= render 'layouts/error_messages', model: f.object %>
     <%= render partial: "form", locals: {f: f} %>
     <%= f.submit "掲載をはじめる", class:"btn btn-success" %>
   </div>

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div class="alert alert-warning">
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Teaparty
     config.load_defaults 6.1
     # デフォルトのロケールを日本に設定
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
     # タイムゾーンを日本時間に設定
     config.time_zone = "Asia/Tokyo"
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,180 @@
 ja:
-  time:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
     formats:
-      default: "%Y/%m/%d %H:%M:%S"
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,18 @@
+ja:
+  activerecord:
+    models:
+      experience: 体験
+    attributes:
+      experience:
+        title: タイトル
+        fee: 料金
+        prefecture: 都道府県名
+        region: 地方
+        content: 内容
+        start_datetime: 開始日時
+        finish_datetime: 終了日時
+        language: ガイド言語
+        address: 住所
+        latitude: 緯度
+        longitude: 経度
+        


### PR DESCRIPTION
次のとおり実装しましたので、レビューをお願いします。
## 実装内容
- `experiences`にバリデーションの追加
- 体験登録ページと体験編集ページにエラーメッセージの表示対応 
- エラーメッセージの日本語化
## 参考記事
- [Rails エラーメッセージの表示](https://qiita.com/ryuuuuuuuuuu/items/1a1e53d062bff774d88a)
- [【Rails】validatesのエラーメッセージを日本語化する方法](https://medium-company.com/rails-validates-%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8-%E6%97%A5%E6%9C%AC%E8%AA%9E%E5%8C%96/#Model)